### PR TITLE
removed include malloc.h

### DIFF
--- a/fdlinecombine.c
+++ b/fdlinecombine.c
@@ -5,7 +5,6 @@
  */
 
 #include <stdio.h>
-#include <malloc.h>
 #include <sys/select.h>
 #include <unistd.h>
 #include <fcntl.h>


### PR DESCRIPTION
Enables compilation on OSX, while still compiling on Linux (Ubuntu at least).